### PR TITLE
Allow multiple rolemenus

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -433,10 +433,11 @@ async def edit(msg, *args):
     if len(args) < 3 or len(args) > 4:
         await msg.send("Incorrect number of arguments!\nUsage: <menuName> <add/remove/update> <roleName> [<newRoleName>]")
         return
+    channelName = msg.channel.name
     # Find message to edit
     editMessage = None
     rolemenuKey = None
-    for i in rolemenuData:
+    for i in rolemenuData[channelName]:
         tempMsg = await msg.channel.fetch_message(int(i))
         if "**" + args[0] + "**" in tempMsg.content:
             editMessage = tempMsg
@@ -449,7 +450,7 @@ async def edit(msg, *args):
     if args[1] == "add": # Add a new role to an existing role menu
         newReactionIndex = None
         for i in range(len(reactions)):
-            if reactions[i] not in rolemenuData[rolemenuKey]:
+            if reactions[i] not in rolemenuData[channelName][rolemenuKey]:
                 newReactionIndex = i
                 break
         if newReactionIndex == None or newReactionIndex >= 20:
@@ -458,7 +459,7 @@ async def edit(msg, *args):
         newReaction = reactions[newReactionIndex]
         await editMessage.edit(content=editMessage.content + "\n\n" + newReaction + " " + args[2] + "\n\n")
         await editMessage.add_reaction(newReaction)
-        rolemenuData[rolemenuKey][newReaction] = args[2]
+        rolemenuData[channelName][rolemenuKey][newReaction] = args[2]
         
         f = open("rolemenu.dat", "w")
         json.dump(rolemenuData, f)
@@ -478,7 +479,7 @@ async def edit(msg, *args):
         removeReaction = editMessage.content[startIndex + 2:startIndex + 3]
         await editMessage.edit(content=editMessage.content[:startIndex] + editMessage.content[endIndex:])
         await editMessage.clear_reaction(removeReaction)
-        del(rolemenuData[rolemenuKey][removeReaction])
+        del(rolemenuData[channelName][rolemenuKey][removeReaction])
 
         f = open("rolemenu.dat", "w")
         json.dump(rolemenuData, f)
@@ -499,7 +500,7 @@ async def edit(msg, *args):
             endIndex = startIndex + len(args[2])
         await editMessage.edit(content=editMessage.content[:startIndex] + args[3] + editMessage.content[endIndex:])
         reaction = editMessage.content[startIndex - 2:startIndex - 1]
-        rolemenuData[rolemenuKey][reaction] = args[3]
+        rolemenuData[channelName][rolemenuKey][reaction] = args[3]
 
         f = open("rolemenu.dat", "w")
         json.dump(rolemenuData, f)

--- a/bot.py
+++ b/bot.py
@@ -27,12 +27,13 @@ except:
     sys.exit()
 
 # Load role menu file
+rolemenuData = {}
 try:
     f = open("rolemenu.dat")
     rolemenuData = json.load(f)
     f.close()
 except:
-    rolemenuData = {}
+    pass
 
 # Load locked channel data
 try:
@@ -316,16 +317,16 @@ async def create(msg, *args):
 
     # Accessing the discord API for this much work takes time so we will keep editing a message along the way to inform the user that it's still doing something
     statusMessage = await msg.channel.send("File loaded successfully! Validating file...")
+    global rolemenuData
+    rolemenuData = {}
     # If a rolemenu.dat file exists, load the existing rolemenu data
     try:
         f = open("rolemenu.dat")
-        global rolemenuData
-        data = json.load(f)
+        #global rolemenuData
+        rolemenuData = json.load(f)
         f.close()
     except:
         await statusMessage.edit(content="Creating new rolemenu file...")
-        global rolemenuData
-        rolemenuData = {}
        
     # Check if a channel menu already exists - if the -c argument was given then we will overwrite it. Otherwise we will load the one that currently exists
     createNewMenu = True

--- a/bot.py
+++ b/bot.py
@@ -341,7 +341,7 @@ async def create(msg, *args):
                 channelMenu = rolemenuData[data["roleMenuChannel"]]
                 createNewMenu = False
             else:
-                await statusMessage.edit(content="A role menu exists for the specified channel but the channel appears to be deleted. Run again with -c to clear. Terminating...")
+                await statusMessage.edit(content="A role menu exists for the specified channel but the channel appears to be deleted or inaccessible. Run again with -c to clear the old menu or check my permissions. Terminating...")
                 return
         if len(args) > 1 and args[1] == "-c":
             await statusMessage.edit(content="-c flag included, clearing old role menu...")

--- a/bot.py
+++ b/bot.py
@@ -265,8 +265,8 @@ async def on_raw_reaction_add(reaction):
     
     roles = await reaction.member.guild.fetch_roles()
     # If the message the user reacted to is a rolemenu, get the name of the role related to the reaction they added and give the user that role
-    if str(msg.id) in rolemenuData and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
-        roleName = rolemenuData[str(msg.id)][reaction.emoji.name]
+    if str(msg.id) in rolemenuData[channel.name] and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
+        roleName = rolemenuData[channel.name][str(msg.id)][reaction.emoji.name]
         for i in range(len(roles)):
             if roles[i].name == roleName:
                 await reaction.member.add_roles(roles[i])
@@ -285,8 +285,8 @@ async def on_raw_reaction_remove(reaction):
     msg = await channel.fetch_message(reaction.message_id)
 
     # If the message the user reacted to is a rolemenu, get the name of the role related to the reaction they removed and remove that role from the user
-    if str(msg.id) in rolemenuData and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
-        roleName = rolemenuData[str(msg.id)][reaction.emoji.name]
+    if str(msg.id) in rolemenuData[channel.name] and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
+        roleName = rolemenuData[channel.name][str(msg.id)][reaction.emoji.name]
         for i in range(len(roles)):
             if roles[i].name == roleName:
                 await member.remove_roles(roles[i])

--- a/bot.py
+++ b/bot.py
@@ -262,15 +262,16 @@ async def on_raw_reaction_add(reaction):
             f = open("locked.dat", "w")
             json.dump(data, f)
             f.close()
-            return
+        return
     
-    roles = await reaction.member.guild.fetch_roles()
-    # If the message the user reacted to is a rolemenu, get the name of the role related to the reaction they added and give the user that role
-    if str(msg.id) in rolemenuData[channel.name] and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
-        roleName = rolemenuData[channel.name][str(msg.id)][reaction.emoji.name]
-        for i in range(len(roles)):
-            if roles[i].name == roleName:
-                await reaction.member.add_roles(roles[i])
+    if channel.name in rolemenuData:
+        roles = await reaction.member.guild.fetch_roles()
+        # If the message the user reacted to is a rolemenu, get the name of the role related to the reaction they added and give the user that role
+        if str(msg.id) in rolemenuData[channel.name] and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
+            roleName = rolemenuData[channel.name][str(msg.id)][reaction.emoji.name]
+            for i in range(len(roles)):
+                if roles[i].name == roleName:
+                    await reaction.member.add_roles(roles[i])
 
 @client.event
 async def on_raw_reaction_remove(reaction):
@@ -285,12 +286,13 @@ async def on_raw_reaction_remove(reaction):
     channel = client.get_channel(reaction.channel_id)
     msg = await channel.fetch_message(reaction.message_id)
 
-    # If the message the user reacted to is a rolemenu, get the name of the role related to the reaction they removed and remove that role from the user
-    if str(msg.id) in rolemenuData[channel.name] and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
-        roleName = rolemenuData[channel.name][str(msg.id)][reaction.emoji.name]
-        for i in range(len(roles)):
-            if roles[i].name == roleName:
-                await member.remove_roles(roles[i])
+    if channel.name in rolemenuData:
+        # If the message the user reacted to is a rolemenu, get the name of the role related to the reaction they removed and remove that role from the user
+        if str(msg.id) in rolemenuData[channel.name] and msg.author == client.user: # The message id comes in as an integer but is serialised as a string when saved to JSON
+            roleName = rolemenuData[channel.name][str(msg.id)][reaction.emoji.name]
+            for i in range(len(roles)):
+                if roles[i].name == roleName:
+                    await member.remove_roles(roles[i])
 
 ##### ROLE MENU #####
 
@@ -393,11 +395,9 @@ async def create(msg, *args):
         await statusMessage.edit(content="Role menu channel created! Generating menu...")
     else:
         await statusMessage.edit(content="Role menu channel found! Generating menu...")
-        #pass ????
-        # I don't think I need this but I don't want to remove it yet just in case
-        for i in guild.channels: #
-            if i.name == data["roleMenuChannel"]: #
-                roleMenuChannel = i #
+        for i in guild.channels:
+            if i.name == data["roleMenuChannel"]:
+                roleMenuChannel = i
     
     if createNewMenu:
         await roleMenuChannel.send("Welcome to the course selection channel! React to a message below to gain access to a text channel for that subject")

--- a/bot.py
+++ b/bot.py
@@ -336,9 +336,19 @@ async def create(msg, *args):
     if data["roleMenuChannel"] in rolemenuData:
         # This seems obsolete to check the flag like this but on the offchance that more flags get introduced to this command later this will ensure it doesn't clash
         if len(args) < 2 or len(args) > 1 and args[1] != "-c":
-            await statusMessage.edit(content="Role Menu already exists, appending to existing menu...")
-            channelMenu = rolemenuData[data["roleMenuChannel"]]
-            createNewMenu = False
+            if any(channel.name == data["roleMenuChannel"] for channel in guild.channels):
+                await statusMessage.edit(content="Role menu already exists, appending to existing menu...")
+                channelMenu = rolemenuData[data["roleMenuChannel"]]
+                createNewMenu = False
+            else:
+                await statusMessage.edit(content="A role menu exists for the specified channel but the channel appears to be deleted. Run again with -c to clear. Terminating...")
+                return
+        if len(args) > 1 and args[1] == "-c":
+            await statusMessage.edit(content="-c flag included, clearing old role menu...")
+            # Further down when generating the role menu, the decision to make a new channel or not is made by seeing whether a menu exists in rolemenuData
+            # If we are clearing with the -c argument we should clear the old menu from rolemenuData
+            del(rolemenuData[data["roleMenuChannel"]])
+            
     
     # Find sinbin role
     sinbinRole = None


### PR DESCRIPTION
This will require a manual update to existing rolemenu data file to match this new format when merged
Essentially instead of storing the menu baremetal in the json it is indexed by channel name allowing multiple role menu channels to co-exist